### PR TITLE
Refactor: registry.tsx spinner for better dark mode visibility

### DIFF
--- a/src/app/registry/registry.tsx
+++ b/src/app/registry/registry.tsx
@@ -11,7 +11,7 @@ const componentsRegistry: Record<string, RegisteredComponent> =
       {
         loading: () => (
           <div className="flex items-center justify-center space-x-2 p-2">
-            <div className="h-4 w-4 animate-spin rounded-full border-2 border-t-transparent border-black dark:border-white"></div>
+            <div className="h-4 w-4 animate-spin rounded-full border-2 border-black border-t-transparent dark:border-white dark:border-t-black"></div>
             <span className="text-sm  overflow-hidden whitespace-nowrap ">
               Loading...
             </span>


### PR DESCRIPTION
# This refactors the loading spinner in registry.tsx to improve visibility in dark mode.

- In dark mode, the spinner was not visibly animating because:
- border-t-transparent removed the top border.
- dark:border-white made the rest of the spinner white.
- With no visible contrast on a dark background, the animation appeared static.

Updated the spinner class from:

```tsx
border-2 border-t-transparent border-black dark:border-white
```
to:

```tsx
border-2 border-black border-t-transparent dark:border-white dark:border-t-black
```

# Checklist

- [x] Already rebased against main branch.

