### PR TITLE
refactor: added canonical

### DIFF
--- a/src/app/docs/[[...slug]]/page.tsx
+++ b/src/app/docs/[[...slug]]/page.tsx
@@ -107,6 +107,7 @@ export async function generateMetadata({ params }: PageProps) {
   const resolvedParams = await params;
   const slug = resolvedParams.slug || ["introduction"];
   const doc = await getDocBySlug(slug);
+  const url = `https://scrollxui.dev/docs/${slug.join("/")}`;
 
   if (!doc) {
     return {
@@ -115,28 +116,31 @@ export async function generateMetadata({ params }: PageProps) {
       openGraph: {
         title: "Not Found",
         description: "The page you are looking for does not exist.",
-        url: `https://scrollx-ui.vercel.app/docs/${slug.join("/")}`,
+        url,
         images: [
           {
-            url: "https://scrollx-ui.vercel.app/images/ui.png",
+            url: "https://scrollxui.dev/images/ui.png",
             width: 1200,
             height: 630,
             alt: "ScrollX UI",
           },
         ],
       },
+      alternates: {
+        canonical: url,
+      },
     };
   }
 
   const componentName = slug[slug.length - 1];
-  let imageUrl = "https://scrollx-ui.vercel.app/images/ui.png";
+  let imageUrl = "https://scrollxui.dev/images/ui.png";
 
   if (slug.includes("components") && componentName) {
-    imageUrl = `https://scrollx-ui.vercel.app/api/og?title=${encodeURIComponent(
+    imageUrl = `https://scrollxui.dev/api/og?title=${encodeURIComponent(
       doc.frontmatter.title
     )}&description=${encodeURIComponent(
       doc.frontmatter.description || ""
-    )}&logo=https://scrollx-ui.vercel.app/favicon.ico`;
+    )}&logo=https://scrollxui.dev/favicon.ico`;
   }
 
   return {
@@ -145,7 +149,7 @@ export async function generateMetadata({ params }: PageProps) {
     openGraph: {
       title: `ScrollX UI | ${doc.frontmatter.title}`,
       description: doc.frontmatter.description,
-      url: `https://scrollx-ui.vercel.app/docs/${slug.join("/")}`,
+      url,
       images: [
         {
           url: imageUrl,
@@ -160,6 +164,9 @@ export async function generateMetadata({ params }: PageProps) {
       title: `ScrollX UI | ${doc.frontmatter.title}`,
       description: doc.frontmatter.description,
       images: [imageUrl],
+    },
+    alternates: {
+      canonical: url,
     },
   };
 }

--- a/src/app/docs/components/page.tsx
+++ b/src/app/docs/components/page.tsx
@@ -77,11 +77,11 @@ export default async function ComponentsPage() {
 
       <div className="grid gap-12 sm:grid-cols-2 lg:grid-cols-3">
         {enrichedComponents.map((component) => {
-          const imageUrl = `https://scrollx-ui.vercel.app/api/og?title=${encodeURIComponent(
+          const imageUrl = `https://scrollxui.dev/api/og?title=${encodeURIComponent(
             component.title
           )}&description=${encodeURIComponent(
             component.description
-          )}&logo=https://scrollx-ui.vercel.app/favicon.ico`;
+          )}&logo=https://scrollxui.dev/favicon.ico`;
 
           return (
             <Link

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -63,6 +63,7 @@ export default function RootLayout({
           content="GlvuJNImpIf6gGikeYMVgWIke1V-hohlZaKI_blBh_s"
         />
         <meta name="msvalidate.01" content="3ED2A565E4F3172BA1CC3F2ECAF63CFE" />
+        <link rel="canonical" href={siteConfig.url} />
         <Script
           id="json-ld"
           type="application/ld+json"

--- a/src/lib/getMetadata.ts
+++ b/src/lib/getMetadata.ts
@@ -7,7 +7,7 @@ export function getMetadata({
   description: string;
   path: string;
 }) {
-  const siteUrl = "https://scrollx-ui.vercel.app";
+  const siteUrl = "https://scrollxui.dev";
   const image = `${siteUrl}/api/og?title=${encodeURIComponent(
     title
   )}&description=${encodeURIComponent(description)}`;
@@ -15,6 +15,10 @@ export function getMetadata({
   return {
     title: `ScrollX UI | ${title}`,
     description,
+    metadataBase: new URL(siteUrl),
+    alternates: {
+      canonical: `${siteUrl}${path}`,
+    },
     openGraph: {
       title: `ScrollX UI | ${title}`,
       description,


### PR DESCRIPTION
# Description & Technical Solution

fix: #604

Added canonical URLs for all documentation pages to ensure Google indexes the correct pages and avoids duplicate content warnings.

* Added `<link rel="canonical">` in `RootLayout` for the homepage.
* Updated `generateMetadata()` in MDX docs pages to include:
  `alternates: { canonical: "https://scrollxui.dev/docs/<slug>" }`
* Verified sitemap URLs point to production domain `https://scrollxui.dev` to match canonical URLs.

# Checklist

* [x] Already rebased against main branch
* [x] Added canonical tags to all pages
* [x] Verified sitemap URLs match canonical URLs
* [x] Tested locally and confirmed canonical tags render correctly
