### PR TITLE
fix(ui): Add vertical margin to sidebar component links on hover

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -54,7 +54,7 @@ export default function Sidebar() {
                 key={child.href}
                 href={child.href}
                 className={cn(
-                  "block px-4 py-2 text-sm rounded-md transition-all relative",
+                  "block px-4 py-2 text-sm rounded-md transition-all relative mt-1",
                   pathname === child.href
                     ? "bg-black text-white dark:bg-white dark:text-black"
                     : "text-gray-700 dark:text-gray-400",

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -54,7 +54,7 @@ export default function Sidebar() {
                 key={child.href}
                 href={child.href}
                 className={cn(
-                  "block px-4 py-2 text-sm rounded-md transition-all relative mt-1",
+                  "block px-4 py-2 text-sm rounded-md transition-all relative my-1",
                   pathname === child.href
                     ? "bg-black text-white dark:bg-white dark:text-black"
                     : "text-gray-700 dark:text-gray-400",


### PR DESCRIPTION
# Add vertical margin to sidebar component links

Fixed #616 

## 📜 Description

This pull request resolves the UI bug reported in issue #616, where sidebar links under the "Components" section lacked vertical spacing on hover. This caused adjacent links to merge visually, creating a confusing and inconsistent user experience.

By applying a consistent vertical margin, this PR ensures that each link remains distinct and clearly separated during all interaction states (default, hover, active).

## 🛠️ Technical Solution

-   The fix was implemented by applying the Tailwind CSS utility class `my-1` to the sidebar link component's wrapper.
-   This adds a `0.25rem` margin to the top and bottom of each link, providing the necessary visual separation.
-   The change is scoped only to the affected components and has no side effects on other parts of the sidebar.

## 🧪 How to Verify

1.  Check out this branch and run the application.
2.  Navigate to the sidebar and expand the **"Components"** section.
3.  Hover your mouse over the first and second links (or any two adjacent links).
4.  **Confirm** that a clear visual space now exists between the items and their hover-state backgrounds do not touch.

## 📸 Screenshots

| Before (From Issue #616) | After (This PR) |
| :---: | :---: |
| Links merge on hover. | ✅ Links are clearly separated. |
| *<img width="426" height="675" alt="Sidebar Bug Screenshot" src="https://github.com/user-attachments/assets/8af75c6a-6ef1-4f82-bc2a-25ed7d5116ee" /> * | *<img width="422" height="633" alt="image" src="https://github.com/user-attachments/assets/e0c924ef-1454-407c-a55e-7e37cf4d9585" />* |

---
## ✅ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have rebased my branch against `main`.
- [x] My changes generate no new warnings.
- [x] I have tested my changes on the specified browser/OS (Chrome on Windows).