### PR TITLE
refactor: layout and sidebar updated

### DIFF
--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -11,7 +11,7 @@ export default function DocsLayout({ children }: { children: ReactNode }) {
       <Navbar />
       <div className="flex-1">
         <div className="lg:grid lg:grid-cols-[minmax(16rem,16rem)_1fr_minmax(16rem,16rem)]">
-          <aside className="hidden lg:block w-full sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto border-r border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950">
+          <aside className="hidden lg:block w-full sticky z-[30] top-16 h-[calc(100vh-4rem)] overflow-y-auto border-r border-gray-200 dark:border-gray-800 ">
             <Sidebar />
           </aside>
           <main className="min-w-0 py-8 px-4 lg:px-8">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -13,8 +13,8 @@ export default function Sidebar() {
   return (
     <aside
       className={cn(
-        "fixed left-0 top-0 h-screen w-64 p-6 transition-all duration-300 overflow-y-auto border-r backdrop-blur-xl",
-        "bg-white dark:bg-[#09090b] border-gray-200 dark:border-gray-800"
+        "fixed left-0 top-0 h-screen w-64 p-6 transition-all duration-300 overflow-y-auto border-r",
+        "border-gray-200 dark:border-gray-800"
       )}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}


### PR DESCRIPTION
## Description
- Removed unnecessary `bg` classes from `<aside>` and `<Sidebar />`.
- Added `z-[30]` to `<aside>` for correct stacking above other elements.

## Impact
- Sidebar now has transparent background.

## Files Changed
- `layout.tsx`: `<aside>` updated with `z-[30]` and removed `bg`.
- `Sidebar`: removed `bg` classes.

closes: #623 
