### PR TITLE
refactor: ogimage not using edge runtime now

### DIFF
--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,8 +1,6 @@
 import { ImageResponse } from "next/og";
 import type { NextRequest } from "next/server";
 
-export const runtime = "edge";
-
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const title = searchParams.get("title") || "ScrollX UI";


### PR DESCRIPTION
# Description & Technical Solution

The OG image route was previously using `edge` runtime, which is unnecessary and limits compatibility with Node.js APIs. This caused potential build and runtime issues.

**Impact:**  
- Improved reliability and compatibility of OG image generation.  

**Technical Solution:**  
- Removed `export const runtime = "edge"` from the OG image `route.ts`.  
- Route now defaults to Node.js runtime

fix: #647

# Checklist

- [x] Already rebased against main branch.
