### PR TITLE
feat: <kbd /> added to registry & docs

### DIFF
--- a/public/registry/kbd.json
+++ b/public/registry/kbd.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "kbd",
+  "type": "registry:component",
+  "title": "Kbd",
+  "description": "A component for displaying keyboard shortcuts and key combinations.",
+  "author": "Ahdeetai <https://aditya.is-cool.dev>",
+  "dependencies": ["clsx", "tailwind-merge"],
+  "files": [
+    {
+      "type": "registry:component",
+      "path": "components/ui/kbd.tsx",
+      "target": "components/ui/kbd.tsx",
+      "content": "import { type ComponentProps, type ReactNode } from \"react\";\nimport { cn } from \"@/lib/utils\";\n\nexport type KbdProps = ComponentProps<\"span\"> & {\n  children: ReactNode;\n};\n\nexport const Kbd = ({ className, children, ...props }: KbdProps) => (\n  <span\n    className={cn(\n      \"inline-flex select-none items-center rounded-md border px-2 py-1 text-[10px] font-mono font-medium relative\",\n      \"bg-gradient-to-b from-gray-100 to-gray-200 border-gray-300 shadow-[0_2px_0_#ccc,0_3px_2px_rgba(0,0,0,0.25)]\",\n      \"dark:from-zinc-800 dark:to-zinc-900 dark:border-zinc-700 dark:shadow-[0_2px_0_#222,0_3px_2px_rgba(0,0,0,0.4)]\",\n      \"dark:text-zinc-200\",\n      className\n    )}\n    {...props}\n  >\n    {children}\n  </span>\n);\n\nexport type KbdKeyProps = ComponentProps<\"span\"> & {\n  \"aria-label\"?: string;\n  className?: string;\n};\n\nexport const KbdKey = ({ className, children, ...props }: KbdKeyProps) => (\n  <span\n    className={cn(\n      \"px-1 py-0.25 rounded-sm select-none text-[10px] font-mono font-medium bg-transparent\",\n      className\n    )}\n    {...props}\n  >\n    {children}\n  </span>\n);\n\nexport type KbdSeparatorProps = ComponentProps<\"span\"> & {\n  children?: ReactNode;\n  className?: string;\n};\n\nexport const KbdSeparator = ({ className, children = \"+\", ...props }: KbdSeparatorProps) => (\n  <span\n    className={cn(\n      \"text-muted-foreground/70 text-[10px] mx-0.5 select-none pointer-events-none\",\n      className\n    )}\n    {...props}\n  >\n    {children}\n  </span>\n);"
+    },
+    {
+      "type": "registry:lib",
+      "path": "lib/utils.ts",
+      "target": "lib/utils.ts",
+      "content": "import { clsx, type ClassValue } from \"clsx\";\nimport { twMerge } from \"tailwind-merge\";\n\nexport function cn(...inputs: ClassValue[]) {\n  return twMerge(clsx(inputs));\n}"
+    }
+  ]
+}

--- a/registry.json
+++ b/registry.json
@@ -547,6 +547,21 @@
     },
     {
       "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+      "name": "kbd",
+      "title": "Kbd",
+      "description": "A component for displaying keyboard shortcuts and key combinations.",
+      "type": "registry:component",
+      "dependencies": [""],
+      "files": [
+        {
+          "path": "components/ui/kbd.tsx",
+          "target": "components/ui/kbd.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
+      "$schema": "https://ui.shadcn.com/schema/registry-item.json",
       "name": "kinetic-testimonials",
       "title": "Kinetic Testimonials",
       "description": "Smoothly scrolling, animated testimonials for modern developer websites to showcase user feedback visually.",

--- a/src/app/registry/demos.ts
+++ b/src/app/registry/demos.ts
@@ -62,6 +62,7 @@ export const demoComponents = [
   "holdtoconfirmborder",
   "inputotp-demo",
   "interactiveinput-demo",
+  "kbd-demo",
   "kinetictestimonials-demo",
   "label-demo",
   "lamphome-demo",

--- a/src/app/registry/parents.ts
+++ b/src/app/registry/parents.ts
@@ -36,6 +36,7 @@ export const parentComponents = [
   "hold-toconfirm",
   "input-otp",
   "interactive-input",
+  "kbd",
   "kinetic-testimonials",
   "label",
   "lamphome",

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,6 +10,7 @@ import { ModeToggle } from "./mode-toggle";
 import { SearchModal } from "@/components/SearchModal";
 import { NavSheet } from "@/components/navsheet";
 import ScrollXHeading from "@/components/heading";
+import { Kbd, KbdKey, KbdSeparator } from "@/components/ui/kbd";
 
 interface NavbarProps {
   className?: string;
@@ -109,7 +110,7 @@ export function Navbar({ className }: NavbarProps) {
             </Link>
           </div>
 
-          <nav className="hidden flex-1 items-center space-x-6 md:flex">
+          <nav className="hidden flex-1 items-center space-x-6 lg:flex">
             {routes.map((route) => (
               <Link
                 key={route.href}
@@ -148,9 +149,10 @@ export function Navbar({ className }: NavbarProps) {
                 Search{" "}
                 <span className="hidden xl:inline-block">Components</span>
               </span>
-              <kbd className="pointer-events-none hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex dark:border-neutral-600 dark:bg-neutral-700 dark:text-neutral-300">
-                <span className="text-xs">⌘</span>K
-              </kbd>
+              <Kbd className="pointer-events-none hidden h-5 select-none items-center rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex dark:border-neutral-600 dark:bg-neutral-700 dark:text-neutral-300">
+                <KbdKey aria-label="Meta">⌘</KbdKey>
+                <KbdKey>K</KbdKey>
+              </Kbd>
             </button>
 
             <nav className="flex items-center space-x-2">
@@ -165,11 +167,11 @@ export function Navbar({ className }: NavbarProps) {
                 </Link>
               </Button>
 
-              <div className="hidden md:block">
+              <div className="hidden lg:block">
                 <ModeToggle />
               </div>
 
-              <div className="block md:hidden">
+              <div className="block lg:hidden">
                 <Button
                   variant="ghost"
                   size="icon"

--- a/src/components/demos/kbd-demo.tsx
+++ b/src/components/demos/kbd-demo.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { Kbd, KbdKey, KbdSeparator } from "@/components/ui/kbd";
+
+export default function KbdDemo() {
+  return (
+    <Kbd>
+      <KbdKey aria-label="Meta">⌘</KbdKey>
+      <KbdSeparator className="font-mono text-foreground">+</KbdSeparator>
+      <KbdKey>K</KbdKey>
+    </Kbd>
+  );
+}

--- a/src/components/ui/kbd.tsx
+++ b/src/components/ui/kbd.tsx
@@ -1,0 +1,59 @@
+import { type ComponentProps, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export type KbdProps = ComponentProps<"span"> & {
+  children: ReactNode;
+};
+
+export const Kbd = ({ className, children, ...props }: KbdProps) => (
+  <span
+    className={cn(
+      "inline-flex select-none items-center rounded-md border px-2 py-1 text-[10px] font-mono font-medium relative",
+      "bg-gradient-to-b from-gray-100 to-gray-200 border-gray-300 shadow-[0_2px_0_#ccc,0_3px_2px_rgba(0,0,0,0.25)]",
+      "dark:from-zinc-800 dark:to-zinc-900 dark:border-zinc-700 dark:shadow-[0_2px_0_#222,0_3px_2px_rgba(0,0,0,0.4)]",
+      "dark:text-zinc-200",
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </span>
+);
+
+export type KbdKeyProps = ComponentProps<"span"> & {
+  "aria-label"?: string;
+  className?: string;
+};
+
+export const KbdKey = ({ className, children, ...props }: KbdKeyProps) => (
+  <span
+    className={cn(
+      "px-1 py-0.25 rounded-sm select-none text-[10px] font-mono font-medium bg-transparent",
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </span>
+);
+
+export type KbdSeparatorProps = ComponentProps<"span"> & {
+  children?: ReactNode;
+  className?: string;
+};
+
+export const KbdSeparator = ({
+  className,
+  children = "+",
+  ...props
+}: KbdSeparatorProps) => (
+  <span
+    className={cn(
+      "text-muted-foreground/70 text-[10px] mx-0.5 select-none pointer-events-none",
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </span>
+);

--- a/src/constants/navItems.ts
+++ b/src/constants/navItems.ts
@@ -147,6 +147,11 @@ const navigation: NavItem[] = [
         href: "/docs/components/interactive-input",
       },
       {
+        title: "Kbd",
+        href: "/docs/components/kbd",
+        category: "new",
+      },
+      {
         title: "Kinetic Testimonials",
         href: "/docs/components/kinetic-testimonials",
       },

--- a/src/content/docs/components/kbd.mdx
+++ b/src/content/docs/components/kbd.mdx
@@ -1,0 +1,97 @@
+---
+title: Kbd
+description: A component for displaying keyboard shortcuts and key combinations.
+---
+
+<ComponentPreview
+  name="kbd-demo"
+  className=""
+  description=""
+/>
+
+## Installation
+
+<Tabs defaultValue="cli" className="w-full">
+  <TabsList>
+    <TabsTrigger value="cli">CLI</TabsTrigger>
+    <TabsTrigger value="manual">Manual</TabsTrigger>
+  </TabsList>
+  <TabsContent value="cli">
+    <PkgOptions name="kbd" />
+  </TabsContent>
+  <TabsContent value="manual">
+    <Steps>
+
+
+<Step>Copy and paste the following code into your project.</Step>
+<p>
+  <code>kbd.tsx</code>
+</p>
+<ComponentSource name="kbd" />
+
+<Step>Add util file</Step>
+
+<p>
+  <code>lib/utils.ts</code>
+</p>
+
+
+```tsx
+import { ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+```
+
+</Steps>
+  </TabsContent>
+</Tabs>
+
+## Usage
+
+```tsx
+import { Kbd, KbdKey, KbdSeparator } from "@/components/ui/kbd";
+```
+
+```tsx
+<Kbd>
+    <KbdKey aria-label="Meta">⌘</KbdKey>
+    <KbdSeparator className="font-mono text-foreground">+</KbdSeparator>
+    <KbdKey>K</KbdKey>
+  </Kbd>
+```
+
+
+## API Reference
+
+### Kbd
+
+A component for displaying keyboard shortcuts and key combinations.
+
+## Props
+
+<PropsTable
+  rows={[
+    {
+      prop: "children",
+      type: "ReactNode",
+      default: "required",
+      description: "The content inside the Kbd component, usually the key label or elements."
+    },
+    {
+      prop: "className",
+      type: "string",
+      default: "undefined",
+      description: "Optional additional CSS classes to customize styling."
+    },
+    {
+      prop: "...props",
+      type: "ComponentProps<'span'>",
+      default: "undefined",
+      description: "All other native span element props are supported."
+    }
+  ]}
+/>
+


### PR DESCRIPTION
# Description & Technical Solution**

**Problem / Motivation:**
Currently, ScrollX UI does not have a dedicated component for displaying keyboard shortcuts or key combinations in a consistent UI. Developers need to manually style key sequences, leading to inconsistent look and feel across the app and demos.

**Impact:**
Without this component, documenting shortcuts in the library or demos is harder and visually inconsistent. Adding a reusable `Kbd` component improves developer experience and maintains a cohesive design system.

**Technical Solution:**

* Added `Kbd`, `KbdKey`, and `KbdSeparator` components with light/dark mode support and consistent typography/shadows.
* Created a demo (`kbd-demo.tsx`) and registry entries for cli
* Fully supports custom class names and React `ComponentProps` for flexibility.
* Provides an intuitive API for displaying key sequences with proper spacing and accessibility (`aria-label`).

feat: #690 

**Checklist**

* [x] Already rebased against main branch