### PR TITLE
Feat/card flip

### DIFF
--- a/public/registry/card-flip.json
+++ b/public/registry/card-flip.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "card-flip",
+  "type": "registry:component",
+  "title": "Card Flip",
+  "description": "Renders a card component with flip animation, supporting front/back content.",
+  "author": "Ahdeetai <https://aditya.is-cool.dev>",
+  "dependencies": ["framer-motion", "lucide-react", "clsx", "tailwind-merge"],
+  "files": [
+    {
+      "type": "registry:component",
+      "path": "components/ui/card-flip.tsx",
+      "target": "components/ui/card-flip.tsx",
+      "content": ""
+    },
+    {
+      "type": "registry:lib",
+      "path": "lib/utils.ts",
+      "target": "lib/utils.ts",
+      "content": "import { clsx, type ClassValue } from \"clsx\";\nimport { twMerge } from \"tailwind-merge\";\n\nexport function cn(...inputs: ClassValue[]) {\n  return twMerge(clsx(inputs));\n}"
+    }
+  ]
+}

--- a/registry.json
+++ b/registry.json
@@ -259,6 +259,21 @@
     },
     {
       "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+      "name": "card-flip",
+      "title": "Card Flip",
+      "description": "Renders a card component with flip animation, supporting front/back content.",
+      "type": "registry:component",
+      "dependencies": ["framer-motion", "lucide-react"],
+      "files": [
+        {
+          "path": "components/ui/card-flip.tsx",
+          "target": "components/ui/card-flip.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
+      "$schema": "https://ui.shadcn.com/schema/registry-item.json",
       "name": "carousel",
       "title": "Carousel",
       "description": "A carousel component with card stack visualization for cycling through content.",

--- a/src/app/registry/demos.ts
+++ b/src/app/registry/demos.ts
@@ -27,6 +27,7 @@ export const demoComponents = [
   "codeblocklight",
   "codeblockmultitab",
   "card-demo",
+  "cardflip-demo",
   "carousel-demo",
   "carouselimage-demo",
   "calendar-demo",

--- a/src/app/registry/parents.ts
+++ b/src/app/registry/parents.ts
@@ -17,6 +17,7 @@ export const parentComponents = [
   "border-glide",
   "button",
   "card",
+  "card-flip",
   "carousel",
   "calendar",
   "checkbox-pro",

--- a/src/components/demos/cardflip-demo.tsx
+++ b/src/components/demos/cardflip-demo.tsx
@@ -1,0 +1,126 @@
+"use client";
+import {
+  CardFlip,
+  CardFlipFront,
+  CardFlipBack,
+  CardFlipHeader,
+  CardFlipFooter,
+  CardFlipTitle,
+  CardFlipDescription,
+  CardFlipContent,
+} from "@/components/ui/card-flip";
+import { Button } from "@/components/ui/button";
+import { Box, ShoppingCart, Star } from "lucide-react";
+import { useState } from "react";
+
+export default function CardFlipDemo() {
+  const [selectedSize, setSelectedSize] = useState("36");
+  const sizes = ["34", "35", "36", "37"];
+  return (
+    <CardFlip className="w-full max-w-sm select-none">
+      <CardFlipFront className="flex flex-col justify-between h-auto">
+        <div className="mx-4  h-48 w-[calc(100%-2rem)] rounded-lg overflow-hidden">
+          <img
+            src="https://images.unsplash.com/photo-1634581448750-22a591d78099?w=400&h=300&fit=crop"
+            alt="Auraluxe NovaX Pro"
+            className="w-full h-full object-cover"
+          />
+        </div>
+        <div className=" flex items-center justify-between px-4">
+          <span className="bg-green-500 text-white text-xs font-semibold px-2 py-1 rounded-full">
+            Best Seller
+          </span>
+          <div className="flex items-center space-x-1 text-sm font-medium text-primary/70">
+            <Star className="w-5 h-5 fill-primary text-primary" />
+            <span>4.5 (126)</span>
+          </div>
+        </div>
+        <CardFlipHeader>
+          <CardFlipTitle>Stridera Quantum Aero</CardFlipTitle>
+          <p className="text-2xl p-1 font-bold">$9,499</p>
+          <p className="text-sm font-medium text-foreground">
+            What is your size?
+          </p>
+        </CardFlipHeader>
+        <CardFlipContent className="flex-1 overflow-auto">
+          <div className="flex items-center space-x-2 px-4">
+            {sizes.map((size) => (
+              <Button
+                key={size}
+                size="sm"
+                variant={selectedSize === size ? "default" : "outline"}
+                className="w-8 h-8 p-0 flex items-center justify-center relative"
+                onClick={() => setSelectedSize(size)}
+              >
+                {size}
+              </Button>
+            ))}
+          </div>
+        </CardFlipContent>
+        <CardFlipFooter className="flex gap-4 items-stretch">
+          <button className="flex-1 bg-primary py-1 text-primary-foreground px-4 rounded-lg hover:bg-primary/90 transition-colors flex items-center justify-center">
+            Buy Now
+          </button>
+          <button className="w-12 bg-primary py-1 text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors flex items-center justify-center">
+            <ShoppingCart className="w-5 h-5" />
+          </button>
+        </CardFlipFooter>
+      </CardFlipFront>
+
+      <CardFlipBack className="h-full flex flex-col">
+        <CardFlipHeader>
+          <CardFlipTitle>Stridera Quantum Aero</CardFlipTitle>
+          <CardFlipDescription>Futuristic leather sneakers</CardFlipDescription>
+        </CardFlipHeader>
+        <CardFlipContent className="flex-1 overflow-auto space-y-4">
+          <div className="flex items-start gap-3">
+            <Box className="text-primary w-6 h-6 mt-1" />
+            <div>
+              <h4 className="font-semibold">Upper</h4>
+              <p className="text-sm text-muted-foreground">
+                Premium leather, breathable
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3">
+            <Box className="text-primary w-6 h-6 mt-1" />
+            <div>
+              <h4 className="font-semibold">Sole</h4>
+              <p className="text-sm text-muted-foreground">
+                Carbon-infused, adaptive grip
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3">
+            <Box className="text-primary w-6 h-6 mt-1" />
+            <div>
+              <h4 className="font-semibold">Comfort</h4>
+              <p className="text-sm text-muted-foreground">Memory foam heel</p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3">
+            <Box className="text-primary w-6 h-6 mt-1" />
+            <div>
+              <h4 className="font-semibold">Package</h4>
+              <p className="text-sm text-muted-foreground">
+                Sneakers, dust bag, extra laces
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3">
+            <Box className="text-primary w-6 h-6 mt-1" />
+            <div>
+              <h4 className="font-semibold">Extras</h4>
+              <p className="text-sm text-muted-foreground">
+                Reflective trims for night visibility
+              </p>
+            </div>
+          </div>
+        </CardFlipContent>
+        <CardFlipFooter className="border-t">
+          <p className="text-xs mt-4 ">Free express shipping over $2,999</p>
+        </CardFlipFooter>
+      </CardFlipBack>
+    </CardFlip>
+  );
+}

--- a/src/components/ui/card-flip.tsx
+++ b/src/components/ui/card-flip.tsx
@@ -1,0 +1,171 @@
+"use client";
+import React, { useState } from "react";
+import { motion } from "framer-motion";
+import { Info, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+function CardFlip({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  children: [React.ReactNode, React.ReactNode];
+}) {
+  const [isFlipped, setIsFlipped] = useState(false);
+  const [front, back] = React.Children.toArray(children);
+
+  return (
+    <div
+      className={cn("relative w-full", className)}
+      style={{ perspective: "1000px" }}
+      {...props}
+    >
+      <motion.div
+        className="relative w-full"
+        initial={false}
+        animate={{ rotateY: isFlipped ? -180 : 0 }}
+        transition={{ duration: 0.6, ease: [0.4, 0, 0.2, 1] }}
+        style={{ transformStyle: "preserve-3d" }}
+      >
+        <div className="w-full" style={{ backfaceVisibility: "hidden" }}>
+          <div className="relative w-full">
+            <button
+              onClick={() => setIsFlipped(true)}
+              className="absolute top-4 right-4 p-2 rounded-full hover:bg-muted transition-colors z-10"
+              aria-label="Show info"
+            >
+              <Info className="w-5 h-5 text-muted-foreground" />
+            </button>
+            {front}
+          </div>
+        </div>
+
+        <div
+          className="absolute inset-0 w-full"
+          style={{
+            backfaceVisibility: "hidden",
+            transform: "rotateY(-180deg)",
+          }}
+        >
+          <div className="relative w-full h-full">
+            <button
+              onClick={() => setIsFlipped(false)}
+              className="absolute top-4 right-4 p-2 rounded-full hover:bg-muted transition-colors z-10"
+              aria-label="Close"
+            >
+              <X className="w-5 h-5 text-muted-foreground" />
+            </button>
+            {back}
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+function CardFlipFront({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardFlipBack({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardFlipHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardFlipTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFlipDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFlipAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardFlipContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFlipFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  CardFlip,
+  CardFlipFront,
+  CardFlipBack,
+  CardFlipHeader,
+  CardFlipFooter,
+  CardFlipTitle,
+  CardFlipAction,
+  CardFlipDescription,
+  CardFlipContent,
+};

--- a/src/constants/navItems.ts
+++ b/src/constants/navItems.ts
@@ -79,7 +79,12 @@ const navigation: NavItem[] = [
         href: "/docs/components/border-glide",
       },
       { title: "Button", href: "/docs/components/button" },
-      { title: "Card", href: "/docs/components/card", category: "updated" },
+      { title: "Card", href: "/docs/components/card" },
+      {
+        title: "Card Flip",
+        href: "/docs/components/card-flip",
+        category: "new",
+      },
       { title: "Carousel", href: "/docs/components/carousel" },
       {
         title: "Calendar",

--- a/src/content/docs/components/card-flip.mdx
+++ b/src/content/docs/components/card-flip.mdx
@@ -1,0 +1,164 @@
+---
+title: Card Flip
+description: Renders a card component with flip animation, supporting front/back content.
+---
+
+<ComponentPreview name="cardflip-demo" className="p-8" description="" />
+
+## Installation
+
+<Tabs defaultValue="cli" className="w-full">
+  <TabsList>
+    <TabsTrigger value="cli">CLI</TabsTrigger>
+    <TabsTrigger value="manual">Manual</TabsTrigger>
+  </TabsList>
+  <TabsContent value="cli">
+    <PkgOptions name="card-flip" />
+  </TabsContent>
+  <TabsContent value="manual">
+    <Steps>
+
+<Step>Install the following dependencies:</Step>
+<DepsOptions name="framer-motion" />
+
+<Step>Copy and paste the following code into your project.</Step>
+<p>
+  <code>card-flip.tsx</code>
+</p>
+<ComponentSource name="card-flip" />
+
+<Step>Add util file</Step>
+
+<p>
+  <code>lib/utils.ts</code>
+</p>
+
+```tsx
+import { ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+```
+
+</Steps>
+  </TabsContent>
+</Tabs>
+
+## Usage
+
+```tsx
+import {
+  CardFlip,
+  CardFlipFront,
+  CardFlipBack,
+  CardFlipHeader,
+  CardFlipFooter,
+  CardFlipTitle,
+  CardFlipDescription,
+  CardFlipContent,
+  CardFlipAction,
+} from "@/components/ui/card-flip";
+```
+
+```tsx
+<CardFlip>
+  <CardFlipFront>
+    <CardFlipHeader>
+      <CardFlipTitle>Front Title</CardFlipTitle>
+    </CardFlipHeader>
+    <CardFlipContent>
+      <p>Front Content</p>
+    </CardFlipContent>
+  </CardFlipFront>
+
+  <CardFlipBack>
+    <CardFlipHeader>
+      <CardFlipTitle>Back Title</CardFlipTitle>
+    </CardFlipHeader>
+    <CardFlipContent>
+      <p>Back Content</p>
+    </CardFlipContent>
+  </CardFlipBack>
+</CardFlip>
+```
+
+## API Reference
+
+### Card Flip
+
+Renders a card component with flip animation, supporting front/back content.
+
+## Props
+
+<PropsTable
+  rows={[
+    {
+      prop: "className",
+      type: "string",
+      default: "—",
+      description: "Custom CSS classes for the root card container.",
+    },
+    {
+      prop: "...props",
+      type: "div props",
+      default: "—",
+      description: "All standard HTML div attributes.",
+    },
+    {
+      prop: "children",
+      type: "ReactNode[]",
+      default: "—",
+      description: "Front and back card content as two nodes.",
+    },
+    {
+      prop: "CardFlipFront",
+      type: "React.ReactNode",
+      default: "—",
+      description: "Front side of the card, containing main content.",
+    },
+    {
+      prop: "CardFlipBack",
+      type: "React.ReactNode",
+      default: "—",
+      description: "Back side of the card, shown on flip.",
+    },
+    {
+      prop: "CardFlipHeader",
+      type: "React.ReactNode",
+      default: "—",
+      description: "Header section inside front or back card.",
+    },
+    {
+      prop: "CardFlipTitle",
+      type: "React.ReactNode",
+      default: "—",
+      description: "Title inside the header section.",
+    },
+    {
+      prop: "CardFlipDescription",
+      type: "React.ReactNode",
+      default: "—",
+      description: "Description inside the header section.",
+    },
+    {
+      prop: "CardFlipAction",
+      type: "React.ReactNode",
+      default: "—",
+      description: "Action element (e.g., button) in the header.",
+    },
+    {
+      prop: "CardFlipContent",
+      type: "React.ReactNode",
+      default: "—",
+      description: "Main content area inside the card.",
+    },
+    {
+      prop: "CardFlipFooter",
+      type: "React.ReactNode",
+      default: "—",
+      description: "Footer section inside the card.",
+    },
+  ]}
+/>


### PR DESCRIPTION
# Description & Technical Solution

The existing card components in ScrollX UI do not support flipping between front and back content with smooth animations, making it difficult to create interactive product or info cards.

This addition allows developers to create interactive cards with headers, footers, and actions like "Buy Now" or "Add to Cart" without custom animation logic.

Interactive cards are a common UI pattern for demos, product showcases, and info displays. Adding a reusable CardFlip component improves consistency and reduces development effort.

A new `CardFlip` component was added with front and back slots, supporting headers, footers, and smooth flip animations using Framer Motion. Associated demo, UI, and MDX documentation were also added to showcase usage.

feat: #711 

# Checklist

- [x] Already rebased against main branch
