### PR TITLE
Feat: Copy Page button with markdown serving and AI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # production
 /build
 /dist/
+/public/docs
 
 # misc
 .DS_Store

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ['192.168.31.18'],
   images: {
     unoptimized: true,
     remotePatterns: [
@@ -53,6 +54,24 @@ const nextConfig: NextConfig = {
       {
         source: '/registry',
         destination: '/registry/registry.json',
+      },
+      {
+        source: '/docs/:path*.mdx',
+        destination: '/docs/:path*.md',
+      },
+    ];
+  },
+
+  async headers() {
+    return [
+      {
+        source: '/docs/:path*.md',
+        headers: [
+          {
+            key: 'Content-Type',
+            value: 'text/plain; charset=utf-8',
+          },
+        ],
       },
     ];
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "url": "https://twitter.com/Ahdeetai"
   },
   "scripts": {
-    "dev": "next dev",
+    "copy-md": "tsx scripts/copy-md.ts",
+    "dev": "tsx scripts/copy-md.ts && next dev",
     "build:loader": "tsc -p tsconfig.build.json",
     "prepare:sw": "pnpm build:loader && node --import ./dist/register-ts-node.js scripts/copy-sw.ts",
     "convert": "tsx scripts/convert.ts ./src/content/docs",
@@ -19,7 +20,7 @@
     "populate-block": "tsx scripts/populate-blocks-registry.ts --block",
     "build:registry": "node --import ./dist/register-ts-node.js scripts/build-registry.ts",
     "build:llms": "node --import ./dist/register-ts-node.js scripts/generateLlmsText.ts",
-    "build": "pnpm prepare:sw && pnpm convert && pnpm build:registry && pnpm build:llms && next build",
+    "build": "tsx scripts/copy-md.ts && pnpm prepare:sw && pnpm convert && pnpm build:registry && pnpm build:llms && next build",
     "start": "next start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:file": "eslint",

--- a/scripts/copy-md.ts
+++ b/scripts/copy-md.ts
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const SOURCE_DIR = path.join(__dirname, '..', 'src/content/docs');
+const OUTPUT_DIR = path.join(__dirname, '..', 'public/docs');
+
+function copyMdFiles(srcDir: string, outDir: string): void {
+  if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir, { recursive: true });
+  }
+
+  for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
+    const srcPath = path.join(srcDir, entry.name);
+
+    if (entry.isDirectory()) {
+      copyMdFiles(srcPath, path.join(outDir, entry.name));
+    } else if (entry.name.endsWith('.mdx')) {
+      const mdPath = path.join(outDir, entry.name.replace(/\.mdx$/, '.md'));
+      fs.copyFileSync(srcPath, mdPath);
+      console.log(`✓ ${mdPath.replace(process.cwd(), '')}`);
+    }
+  }
+}
+
+copyMdFiles(SOURCE_DIR, OUTPUT_DIR);
+console.log('Done.');

--- a/src/app/docs/[[...slug]]/page.tsx
+++ b/src/app/docs/[[...slug]]/page.tsx
@@ -141,7 +141,7 @@ export default async function DocsPage({ params }: PageProps) {
             )}
           </div>
           <div className='mt-3 sm:mt-1 shrink-0'>
-            <OpeninAI docUrl={docUrl} />
+            <OpeninAI docUrl={docUrl} mdUrl={`/docs/${slug.join('/')}.md`} />
           </div>
         </div>
       </div>

--- a/src/components/open-ai.tsx
+++ b/src/components/open-ai.tsx
@@ -9,10 +9,12 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, Copy, Check, FileText } from 'lucide-react';
+import { useState } from 'react';
 
 interface OpeninAIProps {
   docUrl: string;
+  mdUrl: string;
 }
 
 const aiOptions = [
@@ -32,51 +34,116 @@ const aiOptions = [
   },
 ];
 
-function OpeninAIMenu({
-  animate,
-  prompt,
-}: {
-  animate: boolean;
-  prompt: string;
-}) {
+function OpeninAIMenu({ prompt, mdUrl }: { prompt: string; mdUrl: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    if (copied) return;
+    try {
+      const res = await fetch(mdUrl);
+      const text = await res.text();
+
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      }
+
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      console.error('Failed to copy');
+    }
+  }
+
   return (
-    <DropdownMenu animate={animate}>
-      <DropdownMenuTrigger asChild>
-        <Button variant='outline' size='sm' className='gap-1.5'>
-          Open in AI
-          <ChevronDown className='w-3.5 h-3.5' />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align='end' className='ml-2 w-fit! min-w-0!'>
-        {aiOptions.map((option) => (
-          <DropdownMenuItem key={option.value} asChild>
-            <Link
-              href={option.getUrl(prompt)}
+    <div className='flex items-center'>
+      <Button
+        variant='outline'
+        size='sm'
+        className='gap-1.5 rounded-r-none border-r-0 w-26.25 justify-start'
+        onClick={handleCopy}
+      >
+        <span className='relative flex items-center justify-center w-3.5 h-3.5 shrink-0'>
+          <Copy
+            className={`absolute w-3.5 h-3.5 transition-all duration-200 ${
+              copied
+                ? 'opacity-0 scale-50 rotate-12'
+                : 'opacity-100 scale-100 rotate-0'
+            }`}
+          />
+          <Check
+            className={`absolute w-3.5 h-3.5 transition-all duration-200 ${
+              copied
+                ? 'opacity-100 scale-100 rotate-0'
+                : 'opacity-0 scale-50 -rotate-12'
+            }`}
+          />
+        </span>
+        <span className='relative h-4 flex items-center'>
+          <span
+            className={`transition-all duration-200 absolute whitespace-nowrap ${
+              copied ? 'opacity-0 -translate-y-2' : 'opacity-100 translate-y-0'
+            }`}
+          >
+            Copy Page
+          </span>
+          <span
+            className={`transition-all duration-200 absolute whitespace-nowrap ${
+              copied ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
+            }`}
+          >
+            Copied!
+          </span>
+        </span>
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant='outline' size='sm' className='rounded-l-none px-2'>
+            <ChevronDown className='w-3.5 h-3.5' />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align='end' className='w-52'>
+          <DropdownMenuItem asChild>
+            <a
+              href={mdUrl}
               target='_blank'
               rel='noopener noreferrer'
               className='flex items-center gap-2'
             >
-              {option.icon}
-              {option.label}
-            </Link>
+              <FileText className='w-4 h-4' />
+              View as Markdown
+            </a>
           </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+          {aiOptions.map((option) => (
+            <DropdownMenuItem key={option.value} asChild>
+              <Link
+                href={option.getUrl(prompt)}
+                target='_blank'
+                rel='noopener noreferrer'
+                className='flex items-center gap-2'
+              >
+                {option.icon}
+                {option.label}
+              </Link>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }
 
-export default function OpeninAI({ docUrl }: OpeninAIProps) {
+export default function OpeninAI({ docUrl, mdUrl }: OpeninAIProps) {
   const prompt = `I'm looking at this scrollxui documentation: ${docUrl}\nHelp me understand how to use it. Be ready to explain concepts, give examples, or help debug based on it.`;
 
-  return (
-    <>
-      <div className='md:hidden'>
-        <OpeninAIMenu animate={false} prompt={prompt} />
-      </div>
-      <div className='hidden md:block'>
-        <OpeninAIMenu animate={true} prompt={prompt} />
-      </div>
-    </>
-  );
+  return <OpeninAIMenu prompt={prompt} mdUrl={mdUrl} />;
 }


### PR DESCRIPTION
# Description & Technical Solution

This PR introduces static markdown serving and a Copy Page button for the ScrollX UI docs.

New Additions
- Build script that copies all .mdx files to public/docs as .md before every build
- next.config.ts rewrites so /docs/*.mdx redirects to /docs/*.md
- Content-Type: text/plain header so .md files display in browser instead of downloading
- Copy Page button with Emil Kowalski style icon animation (Copy → Check)
- Clipboard fallback for non-secure contexts (HTTP on local network)
- Dropdown with View as Markdown, Open in ChatGPT, Open in Claude
- Generated public/docs/ added to .gitignore — regenerated fresh on every Vercel build

Why this matters
- AI tools like Cursor, Copilot and Claude can now consume docs via a predictable URL
- Zero serverless invocations — pure static CDN serving on Vercel
- Keeps ScrollX UI aligned with how shadcn/ui exposes its documentation
- Scales to unlimited requests at zero cost

closes: #941 

# Checklist

- [ ] Already rebased against main branch.

# Screenshots

Provide screenshots or videos of the changes made if any.
