### PR TITLE
fix(theme): prevent dark mode toggle on search input keypress

### DIFF
--- a/src/hooks/useThemeToggle.ts
+++ b/src/hooks/useThemeToggle.ts
@@ -8,6 +8,18 @@ export function useThemeToggle() {
 
   useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        const isTypingField =
+          tag === 'INPUT' ||
+          tag === 'TEXTAREA' ||
+          tag === 'SELECT' ||
+          target.isContentEditable;
+
+        if (isTypingField) return;
+      }
+
       if (
         (event.key === 'd' || event.key === 'D') &&
         !event.ctrlKey &&

--- a/src/hooks/useThemeToggle.ts
+++ b/src/hooks/useThemeToggle.ts
@@ -4,20 +4,24 @@ import { useEffect } from 'react';
 import { useTheme } from 'next-themes';
 
 export function useThemeToggle() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
 
   useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {
       const target = event.target as HTMLElement | null;
+
       if (target) {
         const tag = target.tagName;
-        const isTypingField =
+
+        const isTyping =
           tag === 'INPUT' ||
           tag === 'TEXTAREA' ||
           tag === 'SELECT' ||
-          target.isContentEditable;
+          target.isContentEditable ||
+          target.closest('[contenteditable="true"]') !== null ||
+          target.closest('[role="textbox"]') !== null;
 
-        if (isTypingField) return;
+        if (isTyping) return;
       }
 
       if (
@@ -28,14 +32,11 @@ export function useThemeToggle() {
         !event.shiftKey
       ) {
         event.preventDefault();
-        setTheme(theme === 'dark' ? 'light' : 'dark');
+        setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
       }
     };
 
     window.addEventListener('keydown', handleKeyPress);
-
-    return () => {
-      window.removeEventListener('keydown', handleKeyPress);
-    };
-  }, [theme, setTheme]);
+    return () => window.removeEventListener('keydown', handleKeyPress);
+  }, [resolvedTheme, setTheme]);
 }


### PR DESCRIPTION
## Description & Technical Solution

### Problem

Pressing the `D` key anywhere in the app was triggering the theme toggle, even when the user was typing inside input fields such as the search modal. This caused a poor user experience, as users were unable to type normally (e.g., typing “d” would switch themes instead of appearing in the input).

### Impact

* Broke typing experience in search input and other form fields
* Unintended theme toggling during user interaction
* Affected usability of keyboard-driven UI

### Solution

Added a guard in the global `keydown` listener to detect when the user is interacting with input elements (`input`, `textarea`, `select`, and contenteditable fields).

If the event originates from a typing context, the theme toggle logic is skipped. Otherwise, pressing `D` continues to toggle between light and dark mode as intended.

This ensures:

* Normal typing behavior inside inputs
* Theme shortcut still works globally outside typing contexts

---

## Checklist

* [x] Already rebased against main branch
* [x] Fix tested in search input and other interactive fields
* [x] No regression in global theme toggle behavior

---

Closes: #943

